### PR TITLE
Vectorized for loops in randall_from_df() gives 5x speed up

### DIFF
--- a/R/randall_from_df.R
+++ b/R/randall_from_df.R
@@ -211,23 +211,16 @@ randall_from_df<-function(df_list, description, ord = "circular6"){
           ii<-ii+1
           scal2[ii]<-dmatp[i,j]}}
 
-
-
       #match data matc with mathyp  1=conf 2=tie, 3=less
 
-      matc2 <-matrix(nrow=np,ncol=np)
-      for(i in 1:np){
-        for(j in 1:np){
-          if(scal2[j] > scal2[i]) matc2[i,j] <- 1
-          if(scal2[j] == scal2[i]) matc2[i,j] <- 2
-          if(scal2[j] < scal2[i]) matc2[i,j] <- 0}}
+      # Replace first pair of nested for loops with vectorized operations
+      matc2 <- matrix(nrow = np, ncol = np)
+      matc2[] <- as.numeric(scal2[rep(1:np, each = np)] > scal2[rep(1:np, np)])
+      matc2[scal2[rep(1:np, each = np)] == scal2[rep(1:np, np)]] <- 2
 
-      nsup<-0
-      nntie<-0
-      for(i in 1:np){
-        for(j in 1:np){
-          if(matc2[i,j]==1 & mathyp[i,j]==1) nsup<-nsup+1
-          if(matc2[i,j]==2 & mathyp[i,j]==1) nntie<-nntie+1}}
+      # Replace second pair of nested for loops with vectorized operations
+      nsup <- sum(matc2 == 1 & mathyp == 1)
+      nntie <- sum(matc2 == 2 & mathyp == 1)
 
       if(nsup >= nagr) count <- count+1   #count number of cases where fit is equal or greater
 


### PR DESCRIPTION
I have been experimenting with some RTHOR for analysing circumplex data and realised there were some simple fixes to speed up the randall functions. There were a few nested for loops that were massively slowing down the computation, so I was able to vectorize them and get about 5x faster.

Here's some screenshots of my RStudio profiling runs on two dataframes with 8 columns:
```r
randall_df_output <- my_randall_from_df(list(mat_1, mat_2), c("Ordered", "Random_1"), ord="circular8")
```

![Before Profile](https://github.com/michaellynnmorris/RTHORR/assets/22335636/05bf2391-4da9-4dda-adca-63d70e030192)

vs the new version:

![After profile](https://github.com/michaellynnmorris/RTHORR/assets/22335636/8d7220c8-ec0e-46ce-bded-6e4cdde6b859)

At least on my data, I've confirmed I get identical results.

I'm sure there's lots more that could be done, and I've only tested it out on the `randall_from_df()` function since that's what I needed at the moment, but I thought I'd submit it if anyone else is using this! I think it'd be easier to replicate in the other functions as well.